### PR TITLE
Add markdown helper plugins 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ lets you view and cycle through your previous copy and paste registers on the fl
 * [rainbow-parentheses](https://github.com/kien/rainbow_parentheses.vim) highlights nested parentheses, brackets, and curly braces with differing colors so you can match them up more easily.
   * Use `,rp` to toggle rainbow parenthesis mode in the current file. By default it is off.
 
+## Markdown 
+* [Goyo](https://github.com/junegunn/goyo.vim) Distraction-free writing in Vim. Sets the width and height of the text area and centers it. Activate with `:Goyo` and turn it off with `:Goyo!`
+* [vim-pencil](https://github.com/reedes/vim-pencil) wraps the text, while allowing natural `jk` movements up and down in the paragraph
+  * `:SoftPencil`:  soft-line wrap mode
+  * `:HardPencil`:  hard-line wrap mode
+
 ## Window Management
 * [ZoomWin](http://www.vim.org/scripts/script.php?script_id=508) lets you close all other windows with `<C-w>o`.  You can restore all the closed windows with the same command.  Useful with `:tabo` to close everything but what you're working on.
 

--- a/init/language.vim
+++ b/init/language.vim
@@ -36,5 +36,21 @@ autocmd BufRead,BufNewFile *.jasmine_fixture set filetype=html
 " Insert ' => '
 autocmd FileType ruby imap  <Space>=><Space>
 
+" Markdown
+" .md, .mdx files read as markdown
+autocmd BufNewFile,BufRead *.md set filetype=markdown
+autocmd BufNewFile,BufRead *.mdx set filetype=markdown
+
 " Open all folds in Markdown.
-autocmd FileType mkd normal zR
+autocmd FileType markdown normal zR
+
+" Soft wrap markdown and open in focus mode
+let g:pencil#wrapModeDefault = 'soft'
+
+" Uncomment below to open markdown files in 'focus' mode
+" autocmd BufRead *.md* :Goyo
+
+augroup pencil
+  autocmd!
+  autocmd FileType markdown call pencil#init()
+augroup END

--- a/vimrc
+++ b/vimrc
@@ -134,6 +134,12 @@ else
   Plugin 'elixir-lang/vim-elixir'
 
   "
+  " Markdown helpers
+  "
+  Plugin 'junegunn/goyo.vim'
+  Plugin 'reedes/vim-pencil'
+
+  "
   " Development Tool Integration
   "
   Plugin 'tpope/vim-fugitive'


### PR DESCRIPTION
Hopes to alleviate some pain points when it comes to editing markdown
files in Vim - that the keyboard navigation tends to get very wonky when
the text is soft-wrapped, and also the illegibility of reading prose
that stretches the full-length of a large window. Plugin `Goyo` restricts
the width of the text & centers it (focus mode) and `pencil` adjusts the
navigation key mappings to something a little more intuitive.